### PR TITLE
FIX: Add missing includes in cmd_system.c for ESP-IDF 5.3+ (PlatformIO)

### DIFF
--- a/components/cmd_system/cmd_system.c
+++ b/components/cmd_system/cmd_system.c
@@ -18,6 +18,7 @@
 #include <argtable3/argtable3.h>
 #include <driver/rtc_io.h>
 #include <driver/uart.h>
+#include <driver/gpio.h>
 #include <esp_chip_info.h>
 #include <esp_console.h>
 #include <esp_flash.h>


### PR DESCRIPTION
**Description of the issue:**
When compiling this template using PlatformIO with newer versions of the ESP-IDF framework (specifically v5.3+), the build fails during the compilation of `cmd_system.c`. The compiler throws an `implicit declaration of function 'gpio_wakeup_enable'` error. 

This happens because newer ESP-IDF versions no longer implicitly include the GPIO driver headers globally, and since PlatformIO users rely on this static copy of `cmd_system`, the build breaks.

**The Fix:**
I just added `#include <driver/gpio.h>` to `cmd_system.c`. This explicitly declares the missing functions and allows the project to compile successfully on modern PlatformIO setups without breaking compatibility with older versions.